### PR TITLE
remove duplicated 'id' property from Player

### DIFF
--- a/Assets/Player.cs
+++ b/Assets/Player.cs
@@ -9,12 +9,9 @@ using Colyseus.Schema;
 
 public partial class Player : Entity {
 	[Type(9, "string")]
-	public string id = default(string);
-
-	[Type(10, "string")]
 	public string sessionId = default(string);
 
-	[Type(11, "boolean")]
+	[Type(10, "boolean")]
 	public bool connected = default(bool);
 }
 

--- a/Server/package.json
+++ b/Server/package.json
@@ -6,7 +6,7 @@
     "url": "git://github.com/colyseus/colyseus-unity3d.git"
   },
   "scripts": {
-    "schema-codegen": "schema-codegen DemoRoom.ts --csharp --output ../Assets/",
+    "schema-codegen": "schema-codegen rooms/TankRoomAlpha.ts --csharp --output ../Assets/",
     "start": "nodemon --watch '**.ts' --exec ts-node ./index.ts"
   },
   "engines": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@colyseus/social": "^0.10.0",
-    "colyseus": "^0.14.1",
+    "colyseus": "^0.14.13",
     "cors": "^2.8.5",
     "express": "^4.13.3",
     "express-jwt": "^5.3.1",

--- a/Server/rooms/TankRoomAlpha.ts
+++ b/Server/rooms/TankRoomAlpha.ts
@@ -19,7 +19,6 @@ class Entity extends Schema {
 }
 
 class Player extends Entity {
-    @type("string") id: string;
     @type("string") sessionId: string;
     @type("boolean") connected: boolean;
 //    @type("number") timestamp: number;


### PR DESCRIPTION
It turns out the "schema-mismatch" error was coming from having a duplicated "id" definition on both Entity + Player.

This PR also:
- Upgrades to the latest `colyseus` version on package.json
- Updates the `npm run schema-codegen` script to use the `TankRoomAlpha` instead of `DemoRoom`
